### PR TITLE
Add basic file management UI

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "shufflr"
+version = "1.0.0"
+edition = "2021"
+description = "Shufflr desktop app"
+
+[dependencies]
+tauri = { version = "1.6", features = [
+    "fs-all",
+    "dialog-all",
+    "path-all",
+    "shell-open",
+    "window-all"
+] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[build-dependencies]
+tauri-build = { version = "1.6", features = [] }
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,1 +1,3 @@
-~yšŠ
+fn main() {
+    tauri_build::build();
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,1 +1,5 @@
-ÿóëz÷§¶Æv+b¢v¥r‰ì¢W°ŠwhÂ‰ÖŠwhÂÈ§
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,93 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+import Header from './components/Header';
+import FileTable from './components/FileTable';
+import FileActionsToolbar from './components/FileActionsToolbar';
+import RenamingPanel from './components/RenamingPanel';
+import ImportOptionsModal from './components/modals/ImportOptionsModal';
+import HelpModal from './components/modals/HelpModal';
+import { open } from '@tauri-apps/api/dialog';
+import { scanDirectory } from './services/fileUtils';
+import { searchDocumentation, getDocumentation } from './services/geminiService';
+import type { FileInfo, ActiveModal } from './types';
 
-// As the full component tree isn't provided, this App component serves as a
-// placeholder to resolve the build error. It will be the root of your application.
-// The actual application UI will be composed of components like Header, FileTable, etc.
 const App: React.FC = () => {
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [searchResult, setSearchResult] = useState('');
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (selected.size === files.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(files.map((f) => f.id)));
+    }
+  };
+
+  const handleImportDirectory = async (options: { includeSubdirectories: boolean; replace: boolean }) => {
+    setActiveModal(null);
+    const dir = await open({ directory: true });
+    if (typeof dir !== 'string') return;
+    const scanned = await scanDirectory(dir, options.includeSubdirectories);
+    setFiles(options.replace ? scanned : [...files, ...scanned]);
+  };
+
+  const handleHelpSearch = useCallback(async (q: string) => {
+    setSearchLoading(true);
+    const result = await searchDocumentation(q);
+    setSearchResult(result);
+    setSearchLoading(false);
+  }, []);
+
+  const applyRename = (updated: FileInfo[]) => {
+    setFiles(updated);
+    setIsRenaming(false);
+    setSelected(new Set());
+  };
+
   return (
-    <div className="bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-200 min-h-screen font-sans">
-        <div className="container mx-auto p-4">
-            <h1 className="text-4xl font-bold text-center text-slate-900 dark:text-slate-100 p-8">
-                Shufflr
-            </h1>
-            <p className="text-center text-lg text-slate-600 dark:text-slate-400 -mt-4">
-                The main application components will be rendered here.
-            </p>
-        </div>
+    <div className="flex flex-col min-h-screen bg-slate-900 text-slate-100">
+      <Header onImportClick={() => setActiveModal('import')} onHelpClick={() => setActiveModal('help')} />
+      {files.length > 0 && !isRenaming && (
+        <FileActionsToolbar disabled={selected.size === 0} onRename={() => setIsRenaming(true)} />
+      )}
+      <main className="flex-1 overflow-auto">
+        <FileTable files={files} selected={selected} onToggle={toggleSelect} onToggleAll={toggleSelectAll} />
+      </main>
+      {isRenaming && (
+        <RenamingPanel
+          files={files.filter((f) => selected.has(f.id))}
+          onApply={applyRename}
+          onCancel={() => setIsRenaming(false)}
+        />
+      )}
+
+      {activeModal === 'import' && (
+        <ImportOptionsModal
+          onClose={() => setActiveModal(null)}
+          onImport={handleImportDirectory}
+          isListPopulated={files.length > 0}
+        />
+      )}
+      {activeModal === 'help' && (
+        <HelpModal
+          onClose={() => setActiveModal(null)}
+          onSearch={handleHelpSearch}
+          searchResult={searchResult}
+          isLoading={searchLoading}
+          documentation={getDocumentation()}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/FileActionsToolbar.tsx
+++ b/src/components/FileActionsToolbar.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface FileActionsToolbarProps {
+  disabled: boolean;
+  onRename: () => void;
+}
+
+const FileActionsToolbar: React.FC<FileActionsToolbarProps> = ({ disabled, onRename }) => (
+  <div className="flex items-center justify-between p-3 bg-slate-800 text-slate-100 border-b border-slate-700">
+    <div className="space-x-3 text-sm">
+      <button className="px-3 py-1 rounded-md bg-slate-700 hover:bg-slate-600" disabled>
+        Search & Collect
+      </button>
+      <button className="px-3 py-1 rounded-md bg-slate-700 hover:bg-slate-600" disabled>
+        Invert Selection
+      </button>
+    </div>
+    <div className="space-x-3 text-sm">
+      <button className="px-3 py-1 rounded-md bg-red-600 hover:bg-red-500" disabled>
+        Delete Permanently
+      </button>
+      <button
+        onClick={onRename}
+        disabled={disabled}
+        className="px-3 py-1 rounded-md bg-cyan-600 hover:bg-cyan-500 disabled:bg-slate-600"
+      >
+        Rename Selected ({disabled ? 0 : ''})
+      </button>
+    </div>
+  </div>
+);
+
+export default FileActionsToolbar;

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { FileIcon, FolderIcon } from './icons';
+import type { FileInfo } from '../types';
+
+interface FileTableProps {
+  files: FileInfo[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  onToggleAll: () => void;
+}
+
+const FileTable: React.FC<FileTableProps> = ({ files, selected, onToggle, onToggleAll }) => {
+  const allSelected = files.length > 0 && selected.size === files.length;
+
+  const formatSize = (size: number | null) => {
+    if (!size) return '-';
+    const kb = size / 1024;
+    if (kb < 1024) return `${kb.toFixed(1)} KB`;
+    return `${(kb / 1024).toFixed(1)} MB`;
+  };
+
+  return (
+    <table className="min-w-full text-sm">
+      <thead className="sticky top-0 bg-slate-900/80 backdrop-blur-sm text-slate-300">
+        <tr>
+          <th className="px-3 py-2"><input type="checkbox" checked={allSelected} onChange={onToggleAll} /></th>
+          <th className="px-3 py-2 text-left">File Name</th>
+          <th className="px-3 py-2 text-left">New Filename</th>
+          <th className="px-3 py-2 text-right">Size</th>
+          <th className="px-3 py-2 text-right">Date Modified</th>
+        </tr>
+      </thead>
+      <tbody>
+        {files.map((f) => (
+          <tr key={f.id} className={selected.has(f.id) ? 'bg-cyan-900/20' : ''}>
+            <td className="px-3 py-2 text-center">
+              <input type="checkbox" checked={selected.has(f.id)} onChange={() => onToggle(f.id)} />
+            </td>
+            <td className="px-3 py-2 flex items-center gap-2">
+              {f.isDir ? <FolderIcon className="w-4 h-4" /> : <FileIcon className="w-4 h-4" />}
+              <span className="truncate" title={f.name}>{f.name}</span>
+            </td>
+            <td className="px-3 py-2">
+              <span className="truncate" title={f.newName}>{f.newName}</span>
+            </td>
+            <td className="px-3 py-2 text-right">{formatSize(f.size)}</td>
+            <td className="px-3 py-2 text-right">{f.dateModified ?? '-'}</td>
+          </tr>
+        ))}
+        {files.length === 0 && (
+          <tr>
+            <td colSpan={5} className="p-6 text-center text-slate-500">
+              <div className="flex flex-col items-center gap-3">
+                <FolderIcon className="w-6 h-6 text-slate-500" />
+                <p>No files loaded. Use the import button above.</p>
+              </div>
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default FileTable;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { FolderIcon, HelpCircleIcon, ShufflrLogoIcon } from './icons';
+
+interface HeaderProps {
+  onImportClick: () => void;
+  onHelpClick: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onImportClick, onHelpClick }) => (
+  <header
+    className="flex items-center justify-between px-4 h-12 backdrop-blur-sm bg-slate-900/60 text-slate-100 select-none"
+    data-tauri-drag-region
+  >
+    <div className="flex items-center gap-2">
+      <ShufflrLogoIcon className="w-6 h-6 text-cyan-500" />
+      <span className="font-semibold text-lg">Shufflr</span>
+    </div>
+    <div className="flex items-center gap-3">
+      <button
+        onClick={onImportClick}
+        className="flex items-center gap-2 bg-cyan-600 hover:bg-cyan-500 text-white text-sm font-medium px-3 py-1.5 rounded-md"
+      >
+        <FolderIcon className="w-4 h-4" /> Import Folder
+      </button>
+      <button
+        onClick={onHelpClick}
+        className="p-2 rounded-md hover:bg-white/10"
+        aria-label="Help"
+      >
+        <HelpCircleIcon className="w-5 h-5" />
+      </button>
+    </div>
+  </header>
+);
+
+export default Header;

--- a/src/components/RenamingPanel.tsx
+++ b/src/components/RenamingPanel.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import type { FileInfo } from '../types';
+import { useRenameHistory } from '../services/useRenameHistory';
+
+interface RenamingPanelProps {
+  files: FileInfo[];
+  onApply: (files: FileInfo[]) => void;
+  onCancel: () => void;
+}
+
+const RenamingPanel: React.FC<RenamingPanelProps> = ({ files, onApply, onCancel }) => {
+  const { state, push, undo, redo, canUndo, canRedo } = useRenameHistory(files);
+  const [removeText, setRemoveText] = useState('');
+
+  const removeTextFromNames = () => {
+    const updated = state.map((f) => ({ ...f, newName: f.newName.replaceAll(removeText, '') }));
+    push(updated);
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-slate-800 text-slate-100 p-4 animate-fade-in-slow">
+      <div className="flex items-end gap-3">
+        <div>
+          <label className="text-sm">Remove Text</label>
+          <input
+            type="text"
+            value={removeText}
+            onChange={(e) => setRemoveText(e.target.value)}
+            className="ml-2 px-2 py-1 rounded-md bg-slate-700"
+          />
+          <button onClick={removeTextFromNames} className="ml-2 px-3 py-1 bg-cyan-600 rounded-md">
+            Apply
+          </button>
+        </div>
+        <div className="flex-grow" />
+        <button onClick={undo} disabled={!canUndo} className="px-3 py-1 bg-slate-700 rounded-md disabled:opacity-50 mr-2">
+          Undo
+        </button>
+        <button onClick={redo} disabled={!canRedo} className="px-3 py-1 bg-slate-700 rounded-md disabled:opacity-50 mr-2">
+          Redo
+        </button>
+        <button onClick={() => onApply(state)} className="px-4 py-1 bg-cyan-600 rounded-md">
+          Commit All Renames
+        </button>
+        <button onClick={onCancel} className="ml-2 px-3 py-1 bg-slate-600 rounded-md">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RenamingPanel;

--- a/src/services/fileUtils.ts
+++ b/src/services/fileUtils.ts
@@ -1,0 +1,30 @@
+import { readDir } from '@tauri-apps/api/fs';
+import type { FileInfo } from '../types';
+
+/**
+ * Recursively scans a directory using Tauri's fs.readDir API.
+ * Note: Tauri's JavaScript API does not currently return file
+ * metadata like size or modified dates, so placeholder values
+ * are used for those fields.
+ */
+export async function scanDirectory(path: string, recursive = true): Promise<FileInfo[]> {
+  const entries = await readDir(path, { recursive });
+
+  const flatten = (items: any[]): FileInfo[] => {
+    return items.flatMap((item) => {
+      const file: FileInfo = {
+        id: item.path,
+        name: item.name || '',
+        path: item.path,
+        isDir: item.children !== undefined,
+        extension: item.name ? item.name.split('.').pop() ?? '' : '',
+        size: null, // Placeholder until Tauri exposes metadata
+        dateModified: null, // Placeholder for same reason
+        newName: item.name || '',
+      };
+      return item.children ? [file, ...flatten(item.children)] : [file];
+    });
+  };
+
+  return flatten(entries);
+}

--- a/src/services/useRenameHistory.ts
+++ b/src/services/useRenameHistory.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+/**
+ * Simple undo/redo history hook used by the RenamingPanel.
+ */
+export function useRenameHistory<T>(initial: T) {
+  const [history, setHistory] = useState([initial]);
+  const [index, setIndex] = useState(0);
+
+  const push = (state: T) => {
+    setHistory((prev) => {
+      const next = prev.slice(0, index + 1);
+      next.push(state);
+      return next;
+    });
+    setIndex((prev) => prev + 1);
+  };
+
+  const undo = () => setIndex((i) => (i > 0 ? i - 1 : i));
+  const redo = () => setIndex((i) => (i < history.length - 1 ? i + 1 : i));
+
+  return {
+    state: history[index],
+    push,
+    undo,
+    redo,
+    canUndo: index > 0,
+    canRedo: index < history.length - 1,
+  } as const;
+}

--- a/src/tauri-shim.d.ts
+++ b/src/tauri-shim.d.ts
@@ -1,0 +1,17 @@
+declare module '@tauri-apps/api/dialog' {
+  export function open(options?: any): Promise<string | string[] | null>;
+  export function confirm(message: string, options?: any): Promise<boolean>;
+}
+
+declare module '@tauri-apps/api/fs' {
+  export interface ReadDirOptions {
+    recursive?: boolean;
+  }
+  export interface FileEntry {
+    name: string | null;
+    path: string;
+    children?: FileEntry[];
+  }
+  export function readDir(path: string, options?: ReadDirOptions): Promise<FileEntry[]>;
+  export function readTextFile(path: string): Promise<string>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+export interface FileInfo {
+  id: string;
+  name: string;
+  newName: string;
+  path: string;
+  isDir: boolean;
+  extension: string;
+  size: number | null;
+  dateModified: string | null;
+}
+
+export type ActiveModal =
+  | null
+  | 'import'
+  | 'help'
+  | 'searchCollect'
+  | 'multiReplace';


### PR DESCRIPTION
## Summary
- implement FileInfo types and modal enum
- add recursive directory scan utility
- provide rename history hook
- build basic components: Header, FileTable, FileActionsToolbar, RenamingPanel
- replace App with working UI wiring components

## Testing
- `npm run build` *(fails: Cannot find module 'react' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882065db0508324afcaad8adfd74855