### PR TITLE
Add Flutter skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Flutter
+.dart_tool/
+build/
+.pub-cache/
+.packages
+flutter_shufflr/pubspec.lock

--- a/flutter_shufflr/README.md
+++ b/flutter_shufflr/README.md
@@ -1,0 +1,11 @@
+# Flutter Shufflr
+
+This directory contains a minimal Flutter implementation of the Shufflr file management app.
+
+## Getting Started
+
+1. Install Flutter SDK.
+2. Run `flutter pub get` in this directory to install dependencies.
+3. Launch the app with `flutter run`.
+
+The app currently allows selecting multiple files using `file_picker` and lists them on screen. Additional file management and renaming features can be implemented following this foundation.

--- a/flutter_shufflr/lib/main.dart
+++ b/flutter_shufflr/lib/main.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+
+void main() {
+  runApp(const ShufflrApp());
+}
+
+class ShufflrApp extends StatelessWidget {
+  const ShufflrApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Shufflr',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  List<String> files = [];
+
+  Future<void> _pickFiles() async {
+    FilePickerResult? result = await FilePicker.platform.pickFiles(allowMultiple: true);
+    if (result != null) {
+      setState(() {
+        files = result.paths.whereType<String>().toList();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Shufflr'),
+      ),
+      body: Column(
+        children: [
+          ElevatedButton(
+            onPressed: _pickFiles,
+            child: const Text('Select Files'),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: files.length,
+              itemBuilder: (context, index) => ListTile(
+                title: Text(files[index]),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_shufflr/pubspec.yaml
+++ b/flutter_shufflr/pubspec.yaml
@@ -1,0 +1,21 @@
+name: flutter_shufflr
+description: Flutter version of the Shufflr file management app.
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  file_picker: ^6.0.0
+  path_provider: ^2.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true
+


### PR DESCRIPTION
## Summary
- add Flutter project skeleton for the Shufflr app
- extend `.gitignore` for Flutter artifacts

## Testing
- `npm run build` *(fails: Cannot find module 'react' and other dependencies)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68836991fccc83249148b03b1243ba39