### PR TITLE
Add Shufflr skeleton app

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,0 +1,1 @@
+export * from './src/main';

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,13 @@
     "allowlist": {
       "all": false,
       "fs": {
-        "all": true,
+        "all": false,
+        "readFile": true,
+        "writeFile": true,
+        "readDir": true,
+        "copyFile": true,
+        "createDir": true,
+        "removeFile": true,
         "scope": [
           "$DOWNLOAD/**",
           "$DOCUMENT/**",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,67 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Header from './components/Header';
+import FileTable from './components/FileTable';
+import HelpModal from './components/modals/HelpModal';
+import { scanDirectory } from './services/fileUtils';
+import { open } from '@tauri-apps/api/dialog';
+import { FileInfo } from './types';
+import { searchDocumentation, getDocumentation } from './services/geminiService';
 
-// As the full component tree isn't provided, this App component serves as a
-// placeholder to resolve the build error. It will be the root of your application.
-// The actual application UI will be composed of components like Header, FileTable, etc.
 const App: React.FC = () => {
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [showHelp, setShowHelp] = useState(false);
+  const [searchResult, setSearchResult] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleImport = async () => {
+    const dir = await open({ directory: true });
+    if (dir && typeof dir === 'string') {
+      const list = await scanDirectory(dir, true);
+      setFiles(list.filter(f => !f.isDir));
+      setSelected(new Set());
+    }
+  };
+
+  const toggle = (path: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path); else next.add(path);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selected.size === files.length) setSelected(new Set());
+    else setSelected(new Set(files.map(f => f.path)));
+  };
+
+  const handleSearch = async (query: string) => {
+    if (!query.trim()) {
+      setSearchResult('');
+      return;
+    }
+    setLoading(true);
+    const result = await searchDocumentation(query);
+    setSearchResult(result);
+    setLoading(false);
+  };
+
   return (
-    <div className="bg-white dark:bg-slate-900 text-slate-800 dark:text-slate-200 min-h-screen font-sans">
-        <div className="container mx-auto p-4">
-            <h1 className="text-4xl font-bold text-center text-slate-900 dark:text-slate-100 p-8">
-                Shufflr
-            </h1>
-            <p className="text-center text-lg text-slate-600 dark:text-slate-400 -mt-4">
-                The main application components will be rendered here.
-            </p>
-        </div>
+    <div className="bg-slate-900 text-slate-100 min-h-screen pt-14 font-sans">
+      <Header onImport={handleImport} onHelp={() => setShowHelp(true)} />
+      <main className="p-4">
+        <FileTable files={files} selected={selected} onToggle={toggle} onToggleAll={toggleAll} />
+      </main>
+      {showHelp && (
+        <HelpModal
+          onClose={() => setShowHelp(false)}
+          onSearch={handleSearch}
+          searchResult={searchResult}
+          isLoading={loading}
+          documentation={getDocumentation()}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { FileInfo } from '../types';
+import { FileIcon, FolderIcon } from './icons';
+
+interface FileTableProps {
+  files: FileInfo[];
+  selected: Set<string>;
+  onToggle: (path: string) => void;
+  onToggleAll: () => void;
+}
+
+const FileTable: React.FC<FileTableProps> = ({ files, selected, onToggle, onToggleAll }) => {
+  const allSelected = files.length > 0 && selected.size === files.length;
+
+  if (files.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-slate-500 dark:text-slate-400">
+        <FolderIcon className="w-12 h-12 mb-4" />
+        <p>No files loaded. Use "Import Folder" to begin.</p>
+      </div>
+    );
+  }
+
+  return (
+    <table className="min-w-full text-sm border-separate border-spacing-y-1">
+      <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
+        <tr>
+          <th className="px-2"><input type="checkbox" checked={allSelected} onChange={onToggleAll} /></th>
+          <th className="text-left px-2">File Name</th>
+          <th className="text-left px-2">New Filename</th>
+          <th className="text-right px-2">Size</th>
+          <th className="text-right px-2">Date Modified</th>
+        </tr>
+      </thead>
+      <tbody>
+        {files.map(file => (
+          <tr key={file.path} className={selected.has(file.path) ? 'bg-cyan-500/10' : ''}>
+            <td className="px-2"><input type="checkbox" checked={selected.has(file.path)} onChange={() => onToggle(file.path)} /></td>
+            <td className="px-2 flex items-center gap-2">
+              {file.isDir ? <FolderIcon className="w-5 h-5" /> : <FileIcon className="w-5 h-5" />}
+              {file.name}
+            </td>
+            <td className="px-2">{file.newName}</td>
+            <td className="px-2 text-right">{file.size ? (file.size / 1024).toFixed(1) + ' KB' : '-'}</td>
+            <td className="px-2 text-right">{file.modified || '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default FileTable;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ShufflrLogoIcon, HelpCircleIcon, FolderIcon } from './icons';
+
+interface HeaderProps {
+  onImport: () => void;
+  onHelp: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onImport, onHelp }) => (
+  <header
+    className="fixed top-0 left-0 right-0 z-40 flex items-center justify-between gap-4 px-4 py-2 bg-slate-800/60 backdrop-blur-md text-slate-200 border-b border-slate-700/50"
+    data-tauri-drag-region
+  >
+    <div className="flex items-center gap-3">
+      <ShufflrLogoIcon className="w-6 h-6 text-cyan-500" />
+      <h1 className="font-bold text-lg">Shufflr</h1>
+    </div>
+    <div className="flex items-center gap-3">
+      <button
+        onClick={onImport}
+        className="px-4 py-1.5 text-sm font-semibold bg-cyan-600 hover:bg-cyan-500 text-white rounded-md flex items-center gap-2"
+      >
+        <FolderIcon className="w-5 h-5" /> Import Folder
+      </button>
+      <button
+        onClick={onHelp}
+        className="p-2 rounded-md hover:bg-slate-700/50"
+        aria-label="Help"
+      >
+        <HelpCircleIcon className="w-5 h-5" />
+      </button>
+    </div>
+  </header>
+);
+
+export default Header;

--- a/src/services/fileUtils.ts
+++ b/src/services/fileUtils.ts
@@ -1,0 +1,36 @@
+import { DirEntry, readDir } from '@tauri-apps/api/fs';
+import { FileInfo } from '../types';
+
+/**
+ * Scan a directory and return an array of FileInfo objects.
+ * Note: Tauri's readDir API does not expose file size or modification
+ * time for entries, so those fields will be undefined.
+ */
+export async function scanDirectory(path: string, recursive = false): Promise<FileInfo[]> {
+  const entries = await readDir(path, { recursive });
+  const results: FileInfo[] = [];
+
+  const mapEntry = (entry: DirEntry, isDir: boolean): FileInfo => ({
+    path: entry.path,
+    name: entry.name ?? '',
+    extension: isDir ? '' : (entry.name?.split('.').pop() || ''),
+    newName: entry.name ?? '',
+    size: entry.metadata?.size, // often undefined
+    modified: entry.metadata?.modified?.toString(),
+    isDir,
+  });
+
+  const visit = (list: DirEntry[]) => {
+    for (const entry of list) {
+      if (entry.children) {
+        if (recursive) visit(entry.children);
+        results.push(mapEntry(entry, true));
+      } else {
+        results.push(mapEntry(entry, false));
+      }
+    }
+  };
+
+  visit(entries);
+  return results;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface FileInfo {
+  path: string;
+  name: string;
+  extension: string;
+  newName: string;
+  size?: number;
+  modified?: string;
+  isDir: boolean;
+}


### PR DESCRIPTION
## Summary
- implement main app layout with header, file table and help modal
- add reusable types and directory scanning utility
- create placeholder header and file table components
- update Tauri config permissions
- expose app entry point through index.tsx

## Testing
- `npm run build` *(fails: missing node modules)*

------
https://chatgpt.com/codex/tasks/task_e_6883cef566488324aeb8f20ee56e3c40